### PR TITLE
Fix variable alias in add_assignment_from_str and typo in grounding.py

### DIFF
--- a/pddl/grounding.py
+++ b/pddl/grounding.py
@@ -101,7 +101,7 @@ class Grounding:
         for name, _ in domain.predicates.items():
             if not self.statics[name]:
                 self.predicate_table.add_symbol(name)
-        # prepare symbol tables for operatorsand functions
+        # prepare symbol tables for operators and functions
         for name, _ in domain.operators.items():
             self.operator_table.add_symbol(name)
         for name, _ in domain.functions.items():

--- a/pddl/problem.py
+++ b/pddl/problem.py
@@ -236,8 +236,8 @@ class Problem:
         if len(self.domain.functions[function_name].typed_parameters) != len(params):
             raise Exception("Function {} has wrong number of parameters.".format(function_name))
         typed_params = []
-        for param, value in zip(self.domain.functions[function_name].typed_parameters, params):
-            typed_params.append(TypedParameter(param.type, param.label,value))
+        for param, param_value in zip(self.domain.functions[function_name].typed_parameters, params):
+            typed_params.append(TypedParameter(param.type, param.label, param_value))
         self.add_assignment(value, AtomicFormula(function_name, typed_params))
 
     def add_assignment(self, value : float, function : AtomicFormula):


### PR DESCRIPTION
There is an issue in problem.py in `add_assignment_from_str` where the value passed as the value parameter gets overwritten in the loop, so the assignment is then incorrect. This fixes it.