### PR TITLE
Grounding and RPG fixes

### DIFF
--- a/plan_graphs/relaxed_plan_graph.py
+++ b/plan_graphs/relaxed_plan_graph.py
@@ -52,7 +52,10 @@ class RelaxedPlanGraph:
                 adds, _ = self.grounding.get_simple_action_effect_from_id(action_id, time_spec)
                 self.action_add_effect_spikes[action_id] = adds
                 self.action_positive_condition_spikes[action_id] = pos
-                self.action_precondition_counts[action_id] = np.count_nonzero(pos)
+                if action_id in self.action_precondition_counts:
+                    self.action_precondition_counts[action_id] += np.count_nonzero(pos)
+                else:
+                    self.action_precondition_counts[action_id] = np.count_nonzero(pos)
 
                 # cache precondition mapping
                 for prop in np.nonzero(pos)[0]:


### PR DESCRIPTION
Some fixes:
1. That the grounding works with supertypes and in cases where an object type is "object" in the domain (may be related to #7, handling of type object may be checked).
2. Fixes in the RPG computation to account for conditions over all and at end, and also at end effects. Discussion on whether this may be problematic may be needed, I think it should be fine (as we're computing a relaxed graph anyway).