### PR TITLE
Fixes in temporal_network.py

### DIFF
--- a/temporal_networks/temporal_network.py
+++ b/temporal_networks/temporal_network.py
@@ -119,9 +119,17 @@ class Constraint:
     def lb(self):
         return self.duration_bound["lb"]
 
+    @lb.setter
+    def lb(self, x):
+        self.duration_bound["lb"] = x
+
     @property
     def ub(self):
         return self.duration_bound["ub"]
+
+    @ub.setter
+    def ub(self, x):
+        self.duration_bound["ub"] = x
 
 class Correlation:
     """

--- a/temporal_networks/temporal_network.py
+++ b/temporal_networks/temporal_network.py
@@ -1,7 +1,6 @@
 #from msilib.schema import Error
 from queue import PriorityQueue
 import json
-from statistics import correlation
 from xmlrpc.client import Boolean
 import copy
 from math import inf


### PR DESCRIPTION
Removing unused import statistics.correlation import which was not found in statistics nor used in the file.

Adding missing setters for ub/lb in Constraint (defined as @property).