### PR TITLE
Fix typo in goal descriptor repr

### DIFF
--- a/pddl/goal_descriptor.py
+++ b/pddl/goal_descriptor.py
@@ -153,7 +153,7 @@ class GoalImplication(GoalDescriptor):
         self.consequent = consequent
 
     def __repr__(self) -> str:
-        return "(imples " + repr(self.antecedent) + " " + repr(self.consequent) + ")"
+        return "(imply " + repr(self.antecedent) + " " + repr(self.consequent) + ")"
 
     def copy(self) -> 'GoalDescriptor':
         return GoalImplication(self.antecedent.copy(), self.consequent.copy())


### PR DESCRIPTION
Based on the PDDL2.1 description, implication goals are (imply <GD> <GD>). OTPL was printing "imples".